### PR TITLE
Change bai to csi for more flexible indexing

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -48,4 +48,4 @@ template:
     - seqera_platform
     - multiqc
     - rocrate
-  version: 1.3.0
+  version: 1.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [[1.3.1](https://github.com/sanger-tol/curationpretext/releases/tag/1.3.1)] - UNSC Pillar-of-Autumn (H1) - [2025-04-02]
+
+### Added and Fixed
+
+- Changed the index format from `bai` to `csi` to be more flexible with large amount of mapping.
+- Correction to CHANGELOG entry on software versions for [[1.3.0](https://github.com/sanger-tol/curationpretext/releases/tag/1.3.0)]
+
 ## [[1.3.0](https://github.com/sanger-tol/curationpretext/releases/tag/1.3.0)] - UNSC Pillar-of-Autumn - [2025-02-27]
 
 ### Added and Fixed
@@ -41,7 +48,7 @@ Note, since the pipeline is using Nextflow DSL2, each process will be run with i
 | `gap_length` ( coreutils )         | 9.1         | REMOVED                    |
 | `reformat_intersect` ( coreutils ) | 9.1         | REMOVED                    |
 | `generate_genome_file` (coreutils) | 9.1         | REMOVED                    |
-| `custom_dumpsoftwareversions`      | -           | Python 3.11.7 + yaml 5.4.1 |
+| `custom_dumpsoftwareversions`      | Python 3.11.7 + yaml 5.4.1           | REMOVED |
 
 ## [[1.2.0](https://github.com/sanger-tol/curationpretext/releases/tag/1.2.0)] - UNSC Spirit-of-Fire - [2025-02-28]
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,6 +18,6 @@ identifiers:
     value: 10.5281/zenodo.12773958
 repository-code: "https://github.com/sanger-tol/curationpretext"
 license: MIT
-version: 1.3.0
+version: 1.3.1
 date-released: "2024-12-13"
 url: "https://pipelines.tol.sanger.ac.uk/curationpretext"

--- a/nextflow.config
+++ b/nextflow.config
@@ -237,7 +237,7 @@ manifest {
     mainScript      = 'main.nf'
     defaultBranch   = 'main'
     nextflowVersion = '!>=24.04.2'
-    version         = '1.3.0'
+    version         = '1.3.1'
     doi             = '10.5281/zenodo.12773958'
 }
 

--- a/subworkflows/local/longread_coverage/main.nf
+++ b/subworkflows/local/longread_coverage/main.nf
@@ -45,7 +45,7 @@ workflow LONGREAD_COVERAGE {
             ch_reads_path,
             reference_tuple.collect(),
             true,
-            "bai",
+            "csi",
             false,
             false,
     )

--- a/tests/main.nf.test.snap
+++ b/tests/main.nf.test.snap
@@ -134,7 +134,7 @@
                     "windowmasker": "1.0.0"
                 },
                 "Workflow": {
-                    "sanger-tol/curationpretext": "v1.3.0"
+                    "sanger-tol/curationpretext": "v1.3.1"
                 }
             },
             [
@@ -146,7 +146,7 @@
             ],
             5,
             [
-                
+
             ],
             0,
             2,


### PR DESCRIPTION
The indexing method needed to be changed from `bai` to `csi`, this makes it much more flexible whilst only minimally increasing storage requirements.