### PR TITLE
Important! Template update for nf-core/tools v3.5.2

### DIFF
--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -30,7 +30,7 @@ lint:
   nextflow_config:
     - manifest.name
     - manifest.homePage
-nf_core_version: 3.5.1
+nf_core_version: 3.5.2
 repository_type: pipeline
 template:
   author: Damon-Lee B Pointon (@DLBPointon)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![nf-test](https://img.shields.io/badge/unit_tests-nf--test-337ab7.svg)](https://www.nf-test.com)
 
 [![Nextflow](https://img.shields.io/badge/version-%E2%89%A525.04.0-green?style=flat&logo=nextflow&logoColor=white&color=%230DC09D&link=https%3A%2F%2Fnextflow.io)](https://www.nextflow.io/)
-[![nf-core template version](https://img.shields.io/badge/nf--core_template-3.5.1-green?style=flat&logo=nfcore&logoColor=white&color=%2324B064&link=https%3A%2F%2Fnf-co.re)](https://github.com/nf-core/tools/releases/tag/3.5.1)
+[![nf-core template version](https://img.shields.io/badge/nf--core_template-3.5.2-green?style=flat&logo=nfcore&logoColor=white&color=%2324B064&link=https%3A%2F%2Fnf-co.re)](https://github.com/nf-core/tools/releases/tag/3.5.2)
 [![run with conda](http://img.shields.io/badge/run%20with-conda-3EB049?labelColor=000000&logo=anaconda)](https://docs.conda.io/en/latest/)
 [![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)
 [![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)


### PR DESCRIPTION
Version `3.5.2` of [nf-core/tools](https://github.com/nf-core/tools) has just been released with updates to the nf-core template. For more details, check out the blog post: None

Please make sure to merge this pull-request as soon as possible, resolving any merge conflicts in the `nf-core-template-merge-3.5.2` branch (or your own fork, if you prefer). Once complete, make a new minor release of your pipeline.

For instructions on how to merge this PR, please see [https://nf-co.re/docs/contributing/sync/](https://nf-co.re/docs/contributing/sync/#merging-automated-prs).

For more information about this release of [nf-core/tools](https://github.com/nf-core/tools), please see the `v3.5.2` [release page](https://github.com/nf-core/tools/releases/tag/3.5.2).

> [!NOTE]
> Since nf-core/tools 3.5.0, older template update PRs will not be automatically closed, but will remain open in your pipeline repository. Older template PRs will be automatically closed once a newer template PR has been merged.