### PR TITLE
Prep for Version 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,20 +3,61 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [[1.6.2](https://github.com/sanger-tol/curationpretext/releases/tag/1.6.2)] - UNSC Trafalgar (H2) - [2025-05-11]
+## [[2.0.0dev](https://github.com/sanger-tol/curationpretext/releases/tag/2.0.0dev)] - Forerunner Audacity  - [2026-09-XX]
+
+## NOTE:
+- The minimum version of nextflow for this pipeline is 26.04 due to the update of `nf-schema` to 2.7.2!
+
+- Added support for new tracks (pebble and busco) which are **NOT** yet implemented.
 
 ## Added and Fixed
 
-- Update nf-core template to 4.1.0.
-  - Note that this update removes the existing Teams and Slack notification functionality. If you were using this functionality, please configure the [nf-slack](https://github.com/seqeralabs/nf-slack) or [nf-teams](https://github.com/nvnieuwk/nf-teams) Nextflow plugins.
+- Update `nf-core` template to 4.1.0
+  - Note that this update removes the existing Teams and Slack notification functionality. If you were using this functionality, please configure the [nf-slack](https://github.com/seqeralabs/nf-slack) or [nf-teams](https://github.com/nvnieuwk/nf-teams) Nextflow plugins
+- Updated `nf-schema` to 2.7.2
+    - This version allows us to use type casting on `params` values input from the cli now that nextflow cli inputs are treated only as strings
+    - In light of this, the casting parameter has been set to `true`
+    - More details can be found on the [nf-core blog](https://nf-co.re/blog/2026/parameter-types)
 - Added flag to control pretext snapshot generation
-- Updated the `LONGREAD_COVERAGE` subworkflow to `SANGER_TOL/READ_COVERAGE` alignments. The end user shouldn't notice any changes.
+- Updated the `LONGREAD_COVERAGE` subworkflow to `SANGER_TOL/READ_COVERAGE` alignments. The end user shouldn't notice any changes
+- Removed the `skip_tracks` parameter
+- Replace `skip_tracks` with a series of track specific parameters
+  - `--run_{track_name}` + `--no_tracks`
+- Added `--juicer_generation` flag, this will generate a juicer map as well as a pretext map
+- Reorganised the aligner selection to the `main.nf` rather than `curationpretext.nf`
+- The `ACCESSORY_FILES` subworkflow has been adapted to closer parity with `sanger-tol/pretext_accessory_files` which will be adopted in a future update
+- Added `--snapshot_annotation` flag, this will generate an annotated pretext annotation file, where each scaffold is labelled with name and size.
+  - WARNING: currently this will not take into account the custom order.
+  - With a custom order , the pretextmap and snapshot will be changed but the annotated snapshot will contain the original order as labels.
+  - A module will be added to subset the sizes file based on the custom order before generating the snapshot.
+- Fixed bug in `CREATE_MAPS_ULTRA` that was checking for "true" rather than "yes", see patch notes for `1.6.1`.
 
 ### Paramters
 
 | Old Version | New Versions          |
 | ----------- | --------------------- |
 | NA          | --snapshot_generation |
+| NA          | --snapshot_annotation |
+| --skip_tracks | --no_tracks |
+| --skip_tracks | --run_coverage |
+| --skip_tracks | --run_gap |
+| --skip_tracks | --run_repeats |
+| --skip_tracks | --run_telomere |
+| NA | --run_busco (placeholder) |
+| NA | --run_pebble (placeholder) |
+| NA          | --juicer_generation |
+
+### Software Dependencies
+
+Note, since the pipeline is using Nextflow DSL2, each process will be run with its own Biocontainer. This means that on occasion it is entirely possible for the pipeline to be using different versions of the same tool. However, the overall software dependency changes compared to the last release have been listed below for reference.
+
+| Module            | Old Version | New Versions |
+| ----------------- | ----------- | ------------ |
+| `PRETEXTANNOTATE` | NA       | 0.1.0        |
+| `SAMTOOLS_DICT` | NA | 1.24 |
+| `SEQKIT_REPLACE` | NA | 2.13.0 |
+| `SEQKIT_SEQ` | NA | 2.13.0 |
+
 
 ## [[1.6.1](https://github.com/sanger-tol/curationpretext/releases/tag/1.6.1)] - UNSC Trafalgar (H1) - [2025-03-13]
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -81,11 +81,6 @@ process {
     //
     // NOTE: GAWK module derivatives
     //
-    withName: 'GAWK_REPLACE_DOTS' {
-        ext.args2 = "'{ gsub(/\\./, \"0\"); print}'"
-        ext.suffix = '_nodot.bed'
-    }
-
     withName: 'GAWK_RENAME_IDS' {
         ext.suffix = '_renamed.bed'
     }
@@ -97,12 +92,6 @@ process {
 
     withName: ".*:GAP_FINDER:GAWK_GAP_LENGTH" {
         ext.suffix = 'gap.bedgraph'
-    }
-
-    withName: 'GAWK_UPPER_SEQUENCE' {
-        ext.args2 = "'/^>/ {print; next} {print toupper(\$0)}'"
-        ext.prefix = { "${meta.id}_UPPER" }
-        ext.suffix = 'fasta'
     }
 
     withName: ".*:TELO_FINDER:GAWK_SPLIT_TELOMERE" {

--- a/main.nf
+++ b/main.nf
@@ -35,35 +35,69 @@ workflow SANGER_TOL_CURATIONPRETEXT {
     cram
     mapped
     snapshot_order
+    snapshot_generation
+    snapshot_annotate
+    juicer_generation
     teloseq
     input_file_string
     aligner
-    skip_tracks
+    run_gap
+    run_telomere
+    run_repeats
+    run_coverage
+    run_busco
+    run_pebble
     run_hires
     run_ultra
     split_telomere
     cram_chunk_size
+    replace_dots
+    track_indexes
+    no_tracks
     outdir
 
     main:
 
+    //
+    // LOGIC: IDEALLY THIS SHOULD BE DONE IN THE PIPELINE_INITIALISATION
+    //        SUBWORKFLOW, HOWEVER, THE VALUE WOULD BE CONVERTED TO A CHANNEL
+    //        WHICH THEN CANNOT BE USED TO GENERATE A STRING FOR THE SW
+    //
+    def fasta_size = file(input_file_string).size()
+    def selected_aligner = (aligner == "AUTO") ?
+        (fasta_size > 5e9 ? "minimap2" : "bwamem2") :
+        aligner
+
+
+    //
+    // WORKFLOW: ACTUAL CURATIONPRETEXT WORKFLOW
+    //
     CURATIONPRETEXT (
         input_fasta,
         reads,
         cram,
         mapped,
         snapshot_order,
+        snapshot_generation,
+        snapshot_annotate,
+        juicer_generation,
         teloseq,
-        input_file_string,
-        aligner,
-        skip_tracks,
+        selected_aligner,
+        run_gap,
+        run_telomere,
+        run_repeats,
+        run_coverage,
+        run_busco,
+        run_pebble,
         run_hires,
         run_ultra,
+        no_tracks,
         split_telomere,
         cram_chunk_size,
+        replace_dots,
+        track_indexes,
         outdir
     )
-    // CURATIONPRETEXT_MAPS
 }
 
 /*
@@ -83,7 +117,7 @@ workflow {
         params.monochrome_logs,
         args,
         params.outdir,
-        [],                      // We are not using the samplesheet for this pipeline
+        [], // We are not using the samplesheet for this pipeline
         params.help,
         params.help_full,
         params.show_hidden
@@ -99,14 +133,25 @@ workflow {
         PIPELINE_INITIALISATION.out.ch_cram_reads,
         PIPELINE_INITIALISATION.out.ch_mapped_bam,
         PIPELINE_INITIALISATION.out.ch_snapshot_order,
+        params.snapshot_generation.toBoolean(),
+        params.snapshot_annotation.toBoolean(),
+        params.juicer_generation.toBoolean(),
         PIPELINE_INITIALISATION.out.teloseq,
         params.input,
         params.aligner,
-        params.skip_tracks,
-        params.run_hires,
+        params.run_gap.toBoolean(),
+        params.run_telomere.toBoolean(),
+        params.run_repeats.toBoolean(),
+        params.run_coverage.toBoolean(),
+        params.run_busco.toBoolean(),
+        params.run_pebble.toBoolean(),
+        params.run_hires.toBoolean(),
         params.run_ultra,
-        params.split_telomere,
+        params.split_telomere.toBoolean(),
         params.cram_chunk_size,
+        params.replace_dots.toBoolean(),
+        params.generate_track_indexes.toBoolean(),
+        params.no_tracks.toBoolean(),
         params.outdir,
     )
 

--- a/modules.json
+++ b/modules.json
@@ -65,7 +65,7 @@
                     "gunzip": {
                         "branch": "master",
                         "git_sha": "96c57dfd98a0641886a67bd449fe33ee2ec0e374",
-                        "installed_by": ["modules"]
+                        "installed_by": ["fasta_clean_faidx", "modules"]
                     },
                     "juicertools/pre": {
                         "branch": "master",
@@ -92,10 +92,15 @@
                         "git_sha": "ab43b6911ab384892fe3753f0ce407b0c23f9d19",
                         "installed_by": ["modules", "pairs_create_contact_maps"]
                     },
+                    "samtools/dict": {
+                        "branch": "master",
+                        "git_sha": "9339809fcb90af8a8b7051e6cd914894d5c52002",
+                        "installed_by": ["fasta_clean_faidx"]
+                    },
                     "samtools/faidx": {
                         "branch": "master",
                         "git_sha": "b2e78932ef01165fd85829513eaca29eff8e640a",
-                        "installed_by": ["bam_samtools_merge_markdup", "modules"]
+                        "installed_by": ["bam_samtools_merge_markdup", "fasta_clean_faidx", "modules"]
                     },
                     "samtools/index": {
                         "branch": "master",
@@ -121,6 +126,16 @@
                         "branch": "master",
                         "git_sha": "b2e78932ef01165fd85829513eaca29eff8e640a",
                         "installed_by": ["modules"]
+                    },
+                    "seqkit/replace": {
+                        "branch": "master",
+                        "git_sha": "d07a945f421a4a91ce4e5a22db63e0e7f8741607",
+                        "installed_by": ["fasta_clean_faidx"]
+                    },
+                    "seqkit/seq": {
+                        "branch": "master",
+                        "git_sha": "d07a945f421a4a91ce4e5a22db63e0e7f8741607",
+                        "installed_by": ["fasta_clean_faidx"]
                     },
                     "seqtk/cutn": {
                         "branch": "master",
@@ -151,6 +166,11 @@
             },
             "subworkflows": {
                 "nf-core": {
+                    "fasta_clean_faidx": {
+                        "branch": "master",
+                        "git_sha": "5a987fb1332540a5fbe3f5eb27f0dd23740ea548",
+                        "installed_by": ["subworkflows"]
+                    },
                     "utils_nextflow_pipeline": {
                         "branch": "master",
                         "git_sha": "c2b22d85f30a706a3073387f30380704fcae013b",
@@ -196,6 +216,11 @@
                         "branch": "main",
                         "git_sha": "2db2b347b5fd5b0e031f10982dd20b44272f6787",
                         "installed_by": ["read_coverage"]
+                    },
+                    "pretextannotate": {
+                        "branch": "main",
+                        "git_sha": "138de7f544587ddc600dd0a3ad3229d27f27c5a9",
+                        "installed_by": ["modules"]
                     },
                     "samtools/mergedup": {
                         "branch": "main",

--- a/modules/nf-core/samtools/dict/environment.yml
+++ b/modules/nf-core/samtools/dict/environment.yml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  # renovate: datasource=conda depName=bioconda/htslib
+  - bioconda::htslib=1.24
+  # renovate: datasource=conda depName=bioconda/samtools
+  - bioconda::samtools=1.24

--- a/modules/nf-core/samtools/dict/main.nf
+++ b/modules/nf-core/samtools/dict/main.nf
@@ -1,0 +1,35 @@
+process SAMTOOLS_DICT {
+    tag "${fasta}"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/e9/e994bf4eb3731150511a14f5706b7bdfd64df1b6d40898fff334286c027e0859/data'
+        : 'community.wave.seqera.io/library/htslib_samtools:1.24--d697cfb9dce007cd'}"
+
+    input:
+    tuple val(meta), path(fasta)
+
+    output:
+    tuple val(meta), path("*.dict"), emit: dict
+    tuple val("${task.process}"), val('samtools'), eval("samtools version | sed '1!d;s/.* //'"), topic: versions, emit: versions_samtools
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    """
+    samtools \\
+        dict \\
+        ${args} \\
+        ${fasta} \\
+        > ${fasta}.dict
+
+    """
+
+    stub:
+    """
+    touch ${fasta}.dict
+    """
+}

--- a/modules/nf-core/samtools/dict/meta.yml
+++ b/modules/nf-core/samtools/dict/meta.yml
@@ -1,0 +1,67 @@
+name: samtools_dict
+description: Create a sequence dictionary file from a FASTA file
+keywords:
+  - dict
+  - fasta
+  - sequence
+tools:
+  - samtools:
+      description: |
+        SAMtools is a set of utilities for interacting with and post-processing
+        short DNA sequence read alignments in the SAM, BAM and CRAM formats, written by Heng Li.
+        These files are generated as output by short read aligners like BWA.
+      homepage: http://www.htslib.org/
+      documentation: http://www.htslib.org/doc/samtools.html
+      doi: 10.1093/bioinformatics/btp352
+      licence: ["MIT"]
+      identifier: biotools:samtools
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - fasta:
+        type: file
+        description: FASTA file
+        pattern: "*.{fa,fasta}"
+        ontologies: []
+output:
+  dict:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.dict":
+          type: file
+          description: FASTA dictionary file
+          pattern: "*.{dict}"
+          ontologies: []
+  versions_samtools:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - samtools:
+          type: string
+          description: The tool name
+      - "samtools version | sed '1!d;s/.* //'":
+          type: string
+          description: The command used to generate the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - samtools:
+          type: string
+          description: The tool name
+      - "samtools version | sed '1!d;s/.* //'":
+          type: string
+          description: The command used to generate the version of the tool
+authors:
+  - "@muffato"
+maintainers:
+  - "@muffato"
+  - "@matthdsm"

--- a/modules/nf-core/samtools/dict/tests/main.nf.test
+++ b/modules/nf-core/samtools/dict/tests/main.nf.test
@@ -1,0 +1,59 @@
+nextflow_process {
+
+    name "Test Process SAMTOOLS_DICT"
+    script "../main.nf"
+    process "SAMTOOLS_DICT"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "samtools"
+    tag "samtools/dict"
+
+    test("sarscov2 - fasta") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(
+                    path(process.out.dict[0][1]).readLines()[0],
+                    process.out.findAll { key, val -> key.startsWith("versions") }
+                    ).match()
+                }
+            )
+        }
+    }
+
+    test("sarscov2 - fasta - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/samtools/dict/tests/main.nf.test.snap
+++ b/modules/nf-core/samtools/dict/tests/main.nf.test.snap
@@ -1,0 +1,48 @@
+{
+    "sarscov2 - fasta - stub": {
+        "content": [
+            {
+                "dict": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "genome.fasta.dict:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_samtools": [
+                    [
+                        "SAMTOOLS_DICT",
+                        "samtools",
+                        "1.24"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-07-10T15:51:47.923681367",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.4"
+        }
+    },
+    "sarscov2 - fasta": {
+        "content": [
+            "@HD\tVN:1.0\tSO:unsorted",
+            {
+                "versions_samtools": [
+                    [
+                        "SAMTOOLS_DICT",
+                        "samtools",
+                        "1.24"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-19T08:57:20.375172",
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/seqkit/replace/environment.yml
+++ b/modules/nf-core/seqkit/replace/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::seqkit=2.13.0

--- a/modules/nf-core/seqkit/replace/main.nf
+++ b/modules/nf-core/seqkit/replace/main.nf
@@ -1,0 +1,61 @@
+process SEQKIT_REPLACE {
+    tag "${meta.id}"
+    label 'process_low'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/4f/4fe272ab9a519cf418160471a485b5ef50ea3f571a8e4555a826f70a4d8243ae/data'
+        : 'community.wave.seqera.io/library/seqkit:2.13.0--05c0a96bf9fb2751'}"
+
+    input:
+    tuple val(meta), path(fastx)
+    val out_ext
+
+    output:
+    tuple val(meta), path("*.fast*"), emit: fastx
+    tuple val("${task.process}"), val('seqkit'), eval("seqkit version | sed 's/^.*v//'"), emit: versions_seqkit, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = "fastq"
+    if ("${fastx}" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz|.+\.faa|.+\.faa.gz/) {
+        extension = "fasta"
+    }
+    def isgz = ""
+    if ("${fastx}" ==~ /.+\.gz/) {
+        isgz = ".gz"
+    }
+    def endswith = out_ext ?: "${extension}${isgz}"
+    """
+    seqkit \\
+        replace \\
+        ${args} \\
+        --threads ${task.cpus} \\
+        -i ${fastx} \\
+        -o ${prefix}.${endswith}
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = "fastq"
+    if ("${fastx}" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz|.+\.faa|.+\.faa.gz/) {
+        extension = "fasta"
+    }
+    def isgz = ""
+    if ("${fastx}" ==~ /.+\.gz/) {
+        isgz = ".gz"
+    }
+    def endswith = out_ext ?: "${extension}${isgz}"
+
+    def create_cmd = endswith.endsWith('gz') ? "echo '' | gzip >" : "touch"
+    """
+    echo ${args}
+
+    ${create_cmd} ${prefix}.${endswith}
+    """
+}

--- a/modules/nf-core/seqkit/replace/meta.yml
+++ b/modules/nf-core/seqkit/replace/meta.yml
@@ -1,0 +1,74 @@
+name: seqkit_replace
+description: Use seqkit to find/replace strings within sequences and sequence headers
+keywords:
+  - seqkit
+  - replace
+  - sequence
+  - sequence headers
+  - fasta
+tools:
+  - seqkit:
+      description: Cross-platform and ultrafast toolkit for FASTA/Q file manipulation,
+        written by Wei Shen.
+      homepage: https://bioinf.shenwei.me/seqkit/usage/
+      documentation: https://bioinf.shenwei.me/seqkit/usage/
+      tool_dev_url: https://github.com/shenwei356/seqkit/
+      doi: "10.1371/journal.pone.016396"
+      identifier: biotools:seqkit
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - fastx:
+        type: file
+        description: fasta/q file
+        pattern: "*.{fasta,fastq,fa,fq,fas,fna,faa}*"
+        ontologies:
+          - edam: http://edamontology.org/format_1930 # FASTQ
+  - out_ext:
+      type: string
+      description: >
+        Output file extension. Leave empty to auto-detect from input (for example
+        `.fasta`, `.fasta.gz`)
+output:
+  fastx:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.fast*":
+          type: file
+          description: fasta/q file with replaced values
+          pattern: "*.{fasta,fastq,fa,fq,fas,fna,faa}*"
+          ontologies:
+            - edam: http://edamontology.org/format_1930 # FASTQ
+  versions_seqkit:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - seqkit:
+          type: string
+          description: The name of the tool
+      - seqkit version | sed 's/^.*v//':
+          type: eval
+          description: The expression to obtain the version of seqkit
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - seqkit:
+          type: string
+          description: The name of the tool
+      - seqkit version | sed 's/^.*v//':
+          type: eval
+          description: The expression to obtain the version of seqkit
+
+authors:
+  - "@mjcipriano"
+maintainers:
+  - "@mjcipriano"

--- a/modules/nf-core/seqkit/replace/tests/main.nf.test
+++ b/modules/nf-core/seqkit/replace/tests/main.nf.test
@@ -1,0 +1,111 @@
+nextflow_process {
+
+    name "Test Process SEQKIT_REPLACE"
+    script "../main.nf"
+    process "SEQKIT_REPLACE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "seqkit"
+    tag "seqkit/replace"
+
+    config "./nextflow.config"
+
+    test("sarscov2 - fasta - replace") {
+        when {
+            params {
+                modules_args = "-s -p 'A' -r 'N'"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/proteome.fasta.gz', checkIfExists: true)
+                ]
+                input[1] = ''
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - fasta - replace - uncompressed") {
+        when {
+            params {
+                modules_args = "-s -p 'A' -r 'N'"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[1] = ''
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - fasta - uncomp - custom") {
+        when {
+            params {
+                modules_args = "-s -p 'T' -r 'N'"
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[1] = 'fasta'
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("sarscov2 - fasta - stub") {
+        options '-stub'
+
+        when {
+            params {
+                modules_args = ""
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                input[1] = ''
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+}

--- a/modules/nf-core/seqkit/replace/tests/main.nf.test.snap
+++ b/modules/nf-core/seqkit/replace/tests/main.nf.test.snap
@@ -1,0 +1,106 @@
+{
+    "sarscov2 - fasta - stub": {
+        "content": [
+            {
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_seqkit": [
+                    [
+                        "SEQKIT_REPLACE",
+                        "seqkit",
+                        "2.13.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-13T12:47:21.226842064",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "sarscov2 - fasta - replace - uncompressed": {
+        "content": [
+            {
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,b1518908253a4997fcad98270751112e"
+                    ]
+                ],
+                "versions_seqkit": [
+                    [
+                        "SEQKIT_REPLACE",
+                        "seqkit",
+                        "2.13.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-12T17:26:01.449665395",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "sarscov2 - fasta - uncomp - custom": {
+        "content": [
+            {
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,05d3294a62c72f5489f067c1da3c2f6c"
+                    ]
+                ],
+                "versions_seqkit": [
+                    [
+                        "SEQKIT_REPLACE",
+                        "seqkit",
+                        "2.13.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-13T12:54:19.323281146",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "sarscov2 - fasta - replace": {
+        "content": [
+            {
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta.gz:md5,c40eaff961f6f2a48bb7e8fd156ed5d7"
+                    ]
+                ],
+                "versions_seqkit": [
+                    [
+                        "SEQKIT_REPLACE",
+                        "seqkit",
+                        "2.13.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-12T17:25:54.471016576",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    }
+}

--- a/modules/nf-core/seqkit/replace/tests/nextflow.config
+++ b/modules/nf-core/seqkit/replace/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: SEQKIT_REPLACE {
+        ext.args = params.modules_args ?: ''
+    }
+}

--- a/modules/nf-core/seqkit/seq/environment.yml
+++ b/modules/nf-core/seqkit/seq/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - bioconda::seqkit=2.13.0

--- a/modules/nf-core/seqkit/seq/main.nf
+++ b/modules/nf-core/seqkit/seq/main.nf
@@ -1,0 +1,63 @@
+process SEQKIT_SEQ {
+    tag "${meta.id}"
+    label 'process_low'
+    // File IO can be a bottleneck. See: https://bioinf.shenwei.me/seqkit/usage/#parallelization-of-cpu-intensive-jobs
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/4f/4fe272ab9a519cf418160471a485b5ef50ea3f571a8e4555a826f70a4d8243ae/data'
+        : 'community.wave.seqera.io/library/seqkit:2.13.0--05c0a96bf9fb2751'}"
+
+    input:
+    tuple val(meta), path(fastx)
+
+    output:
+    tuple val(meta), path("${prefix}.*"), emit: fastx
+    tuple val("${task.process}"), val('seqkit'), eval("seqkit version | sed 's/^.*v//'"), emit: versions_seqkit, topic: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = "fastq"
+    if ("${fastx}" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz|.+\.fsa|.+\.fsa.gz/) {
+        extension = "fasta"
+    }
+    extension = fastx.toString().endsWith('.gz') ? "${extension}.gz" : extension
+    def call_gzip = extension.endsWith('.gz') ? "| gzip -c ${args2}" : ''
+    if ("${prefix}.${extension}" == "${fastx}") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
+    """
+    seqkit \\
+        seq \\
+        --threads ${task.cpus} \\
+        ${args} \\
+        ${fastx} \\
+        ${call_gzip} \\
+        > ${prefix}.${extension}
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def args2 = task.ext.args2 ?: ''
+    prefix = task.ext.prefix ?: "${meta.id}"
+    def extension = "fastq"
+    if ("${fastx}" ==~ /.+\.fasta|.+\.fasta.gz|.+\.fa|.+\.fa.gz|.+\.fas|.+\.fas.gz|.+\.fna|.+\.fna.gz|.+\.fsa|.+\.fsa.gz/) {
+        extension = "fasta"
+    }
+    extension = fastx.toString().endsWith('.gz') ? "${extension}.gz" : extension
+    if ("${prefix}.${extension}" == "${fastx}") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
+    def create_cmd = extension.endsWith('gz') ? "echo '' | gzip >" : "touch"
+    """
+    echo ${args}
+    echo ${args2}
+
+    ${create_cmd} ${prefix}.${extension}
+    """
+}

--- a/modules/nf-core/seqkit/seq/meta.yml
+++ b/modules/nf-core/seqkit/seq/meta.yml
@@ -1,0 +1,71 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "seqkit_seq"
+description: Transforms sequences (extract ID, filter by length, remove gaps, reverse
+  complement...)
+keywords:
+  - genomics
+  - fasta
+  - fastq
+  - transform
+  - filter
+  - gaps
+  - complement
+tools:
+  - "seqkit":
+      description: "A cross-platform and ultrafast toolkit for FASTA/Q file manipulation"
+      homepage: "https://bioinf.shenwei.me/seqkit/"
+      documentation: "https://bioinf.shenwei.me/seqkit/usage/"
+      tool_dev_url: "https://github.com/shenwei356/seqkit"
+      doi: "10.1371/journal.pone.0163962"
+      licence: ["MIT"]
+      identifier: biotools:seqkit
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - fastx:
+        type: file
+        description: Input fasta/fastq file
+        pattern: "*.{fsa,fas,fa,fasta,fastq,fq,fsa.gz,fas.gz,fa.gz,fasta.gz,fastq.gz,fq.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_1930 # FASTQ
+output:
+  fastx:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - ${prefix}.*:
+          type: file
+          description: Output fasta/fastq file
+          pattern: "*.{fasta,fasta.gz,fastq,fastq.gz}"
+          ontologies:
+            - edam: http://edamontology.org/format_1930 # FASTQ
+  versions_seqkit:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - seqkit:
+          type: string
+          description: The name of the tool
+      - seqkit version | sed 's/^.*v//':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - seqkit:
+          type: string
+          description: The name of the tool
+      - seqkit version | sed 's/^.*v//':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@GallVp"
+maintainers:
+  - "@GallVp"

--- a/modules/nf-core/seqkit/seq/tests/main.nf.test
+++ b/modules/nf-core/seqkit/seq/tests/main.nf.test
@@ -1,0 +1,154 @@
+nextflow_process {
+
+    name "Test Process SEQKIT_SEQ"
+    script "../main.nf"
+    process "SEQKIT_SEQ"
+    config './nextflow.config'
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "seqkit"
+    tag "seqkit/seq"
+
+    test("sarscov2-genome_fasta") {
+        when {
+            params {
+                modules_args2 = '-n'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("sarscov2-genome_fasta_gz") {
+        when {
+            params {
+                modules_args2 = '-n'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("sarscov2-test_1_fastq_gz") {
+        when {
+            params {
+                modules_args2 = '-n'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("file_name_conflict-fail_with_error") {
+        when {
+            params {
+                modules_args2 = '-n'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test_1' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.failed
+            assertAll(
+                { assert process.stdout.toString().contains("Input and output names are the same") }
+            )
+        }
+    }
+
+    test("sarscov2-genome_fasta-stub") {
+        options '-stub'
+
+        when {
+            params {
+                modules_args2 = '-n'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert snapshot(sanitizeOutput(process.out)).match() }
+            )
+        }
+    }
+
+    test("file_name_conflict-fail_with_error-stub") {
+        options '-stub'
+
+        when {
+            params {
+                modules_args2 = '-n'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'genome' ], // meta map
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.failed
+            assertAll(
+                { assert process.stdout.toString().contains("Input and output names are the same") }
+            )
+        }
+    }
+}

--- a/modules/nf-core/seqkit/seq/tests/main.nf.test.snap
+++ b/modules/nf-core/seqkit/seq/tests/main.nf.test.snap
@@ -1,0 +1,106 @@
+{
+    "sarscov2-genome_fasta-stub": {
+        "content": [
+            {
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_seqkit": [
+                    [
+                        "SEQKIT_SEQ",
+                        "seqkit",
+                        "2.13.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-14T18:54:38.462339108",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "sarscov2-test_1_fastq_gz": {
+        "content": [
+            {
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fastq.gz:md5,4161df271f9bfcd25d5845a1e220dbec"
+                    ]
+                ],
+                "versions_seqkit": [
+                    [
+                        "SEQKIT_SEQ",
+                        "seqkit",
+                        "2.13.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-12T17:27:53.391265296",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "sarscov2-genome_fasta": {
+        "content": [
+            {
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta:md5,483f4a5dfe60171c86ee9b7e6dff908b"
+                    ]
+                ],
+                "versions_seqkit": [
+                    [
+                        "SEQKIT_SEQ",
+                        "seqkit",
+                        "2.13.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-12T17:27:43.147566645",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    },
+    "sarscov2-genome_fasta_gz": {
+        "content": [
+            {
+                "fastx": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.fasta.gz:md5,483f4a5dfe60171c86ee9b7e6dff908b"
+                    ]
+                ],
+                "versions_seqkit": [
+                    [
+                        "SEQKIT_SEQ",
+                        "seqkit",
+                        "2.13.0"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-12T17:27:48.241605452",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
+    }
+}

--- a/modules/nf-core/seqkit/seq/tests/nextflow.config
+++ b/modules/nf-core/seqkit/seq/tests/nextflow.config
@@ -1,0 +1,5 @@
+process {
+    withName: SEQKIT_SEQ {
+        ext.args2 = params.modules_args2 ?: ''
+    }
+}

--- a/modules/sanger-tol/pretextannotate/environment.yml
+++ b/modules/sanger-tol/pretextannotate/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - pip==26.0.1
+  - pip:
+      - pretextannotate==1.1.2

--- a/modules/sanger-tol/pretextannotate/main.nf
+++ b/modules/sanger-tol/pretextannotate/main.nf
@@ -1,0 +1,44 @@
+process PRETEXTANNOTATE {
+    tag "${meta.id}"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+        ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/3c/3c63c935c52e8af4e4ba9ac16b4ade1ea5f176a373464faec9ab3f9feb3f7ebc/data'
+        : 'community.wave.seqera.io/library/pip_pretextannotate:1fe480fd3b9b3943'}"
+
+    input:
+    tuple val(meta),  path(sizes)
+    tuple val(meta1), path(snapshot)
+
+    output:
+    tuple val(meta), path("*.png"), emit: png
+    tuple val(meta), path("*.gif"), emit: gif
+    tuple val(meta), path("*.tif"), emit: tif
+    tuple val("${task.process}"), val('pretextannotate'), eval("pretextannotate -v | sed 's/pretextannotate. //g'"), topic: versions, emit: versions_pretextannotate
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args    = task.ext.args     ?: ""
+    def prefix  = task.ext.prefix   ?: "${meta.id}"
+
+    """
+    pretextannotate \\
+        --pretext_file ${snapshot} \\
+        --sizes ${sizes} \\
+        --output ./ \\
+        --prefix ${prefix} \\
+        ${args}
+    """
+
+    stub:
+    def prefix  = task.ext.prefix ?: "${meta.id}"
+
+    """
+    touch ${prefix}.png
+    touch ${prefix}.gif
+    touch ${prefix}.tif
+    """
+}

--- a/modules/sanger-tol/pretextannotate/meta.yml
+++ b/modules/sanger-tol/pretextannotate/meta.yml
@@ -1,0 +1,104 @@
+name: "pretextannotate"
+description: |
+  Annotate a pretextmap snapshot with chromosome names, numbers and genomelength
+keywords:
+  - pretext
+  - annotate
+  - png
+  - tif
+  - gif
+tools:
+  - pretextannotate:
+      description: "pretextannotate"
+      homepage: "https://www.github.com/sanger-tol/pretextannotate/"
+      documentation: "https://www.github.com/sanger-tol/pretextannotate/"
+      tool_dev_url: "https://www.github.com/sanger-tol/pretextannotate/"
+      licence:
+        - "MIT"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - sizes:
+        type: file
+        description: |
+          TSV containing chromosome names and lengths
+        pattern: "*.{genome,sizes}"
+        ontologies: []
+  - - meta1:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. `[ id:'sample1' ]`
+    - snapshot:
+        type: file
+        description: |
+          A png snapshot of a pretext map
+        pattern: "*.png"
+        ontologies:
+          - edam: "http://edamontology.org/format_3603"
+output:
+  png:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.png":
+          type: file
+          description: |
+            An annotated png containing a pretextmap and labels
+          ontologies:
+            - edam: "http://edamontology.org/format_3603"
+  gif:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.gif":
+          type: file
+          description: |
+            An annotated gif containing a pretextmap and labels
+          ontologies:
+            - edam: "http://edamontology.org/format_3467"
+  tif:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. `[ id:'sample1' ]`
+      - "*.tif":
+          type: file
+          description: |
+            An annotated tif containing a pretextmap and labels
+          ontologies:
+            - edam: "http://edamontology.org/format_3591"
+  versions_pretextannotate:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - pretextannotate:
+          type: string
+          description: The name of the module
+      - pretextannotate -v | sed 's/pretextannotate. //g':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - pretextannotate:
+          type: string
+          description: The name of the module
+      - pretextannotate -v | sed 's/pretextannotate. //g':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@DLBPointon"
+maintainers:
+  - "@DLBPointon"

--- a/modules/sanger-tol/pretextannotate/tests/main.nf.test
+++ b/modules/sanger-tol/pretextannotate/tests/main.nf.test
@@ -1,0 +1,77 @@
+nextflow_process {
+
+    name "Test Process PRETEXTANNOTATE"
+    script "../main.nf"
+    process "PRETEXTANNOTATE"
+
+    tag "modules"
+    tag "modules_sangertol"
+    tag "pretextannotate"
+
+    test("ilDryDodo1 - sizes, png") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id: "ilDryDodo1"],
+                    file(params.modules_testdata_base_path + 'resources/modules/pretextannotate/ilDryDodo1.1.sizes', checkIfExists: true)
+                ]
+
+                input[1] = [
+                    [id: "ilDryDodo1"],
+                    file(params.modules_testdata_base_path + 'resources/modules/pretextannotate/ilDryDodo1.1_normal_FullMap.png', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert process.success               },
+                // Output graphical images are not stable output, often containing time stamps
+                { assert snapshot([
+                    png_file: file(process.out.png[0][1]).getName(),
+                    tif_file: file(process.out.tif[0][1]).getName(),
+                    gif_file: file(process.out.gif[0][1]).getName(),
+                    versions_pretextannotate: process.out.versions_pretextannotate
+                ]).match() }
+            )
+        }
+    }
+
+    test("ilDryDodo1 - sizes, png - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [id: "ilDryDodo1"],
+                    file(params.modules_testdata_base_path + 'resources/modules/pretextannotate/ilDryDodo1.1.sizes', checkIfExists: true)
+                ]
+
+                input[1] = [
+                    [id: "ilDryDodo1"],
+                    file(params.modules_testdata_base_path + 'resources/modules/pretextannotate/ilDryDodo1.1_normal_FullMap.png', checkIfExists: true)
+                ]
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assertAll(
+                { assert process.success               },
+                { assert snapshot([
+                    png_file: file(process.out.png[0][1]).getName(),
+                    tif_file: file(process.out.tif[0][1]).getName(),
+                    gif_file: file(process.out.gif[0][1]).getName(),
+                    versions_pretextannotate: process.out.versions_pretextannotate
+                ]).match() }
+            )
+        }
+    }
+}

--- a/modules/sanger-tol/pretextannotate/tests/main.nf.test.snap
+++ b/modules/sanger-tol/pretextannotate/tests/main.nf.test.snap
@@ -1,0 +1,44 @@
+{
+    "ilDryDodo1 - sizes, png": {
+        "content": [
+            {
+                "png_file": "ilDryDodo1_annotated_pretext.png",
+                "tif_file": "ilDryDodo1_annotated_pretext.tif",
+                "gif_file": "ilDryDodo1_annotated_pretext.gif",
+                "versions_pretextannotate": [
+                    [
+                        "PRETEXTANNOTATE",
+                        "pretextannotate",
+                        "1.1.2"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-03-05T12:52:01.254429349"
+    },
+    "ilDryDodo1 - sizes, png - stub": {
+        "content": [
+            {
+                "png_file": "ilDryDodo1.png",
+                "tif_file": "ilDryDodo1.tif",
+                "gif_file": "ilDryDodo1.gif",
+                "versions_pretextannotate": [
+                    [
+                        "PRETEXTANNOTATE",
+                        "pretextannotate",
+                        "1.1.2"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-03-05T12:52:09.276682635"
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,14 @@ params {
     // Input options
     input                           = null
     split_telomere                  = false
-    skip_tracks                     = "NONE"
+    generate_track_indexes          = false
+    no_tracks                       = false
+    run_coverage                    = true
+    run_repeats                     = true
+    run_gap                         = true
+    run_telomere                    = true
+    run_busco                       = false
+    run_pebble                      = false
     sample                          = "pretext_rerun"
     teloseq                         = "TTAGGG"
     reads                           = null
@@ -24,10 +31,13 @@ params {
     run_hires                       = true
     run_ultra                       = "yes"
     multi_mapping                   = 0
+    replace_dots                    = false
     cram_chunk_size                 = 10000
     pre_mapped_bam                  = null
     snapshot_order                  = null
     snapshot_generation             = true
+    snapshot_annotation             = false
+    juicer_generation               = false
 
     // Boilerplate options
     outdir                          = "${params.sample}_CPRETEXT_OUTPUT"
@@ -280,14 +290,14 @@ manifest {
     description     = """A simple pipeline to generate pretext files for genomic curation."""
     mainScript      = 'main.nf'
     defaultBranch   = 'master'
-    nextflowVersion = '!>=25.10.4'
-    version         = '1.6.2'
+    nextflowVersion = '!>=26.04.0'
+    version         = '2.0.0dev'
     doi             = '10.5281/zenodo.12773958'
 }
 
 // Nextflow plugins
 plugins {
-    id 'nf-schema@2.5.1' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.7.2' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 // Load modules.config for DSL2 module specific options
@@ -299,3 +309,4 @@ includeConfig 'subworkflows/sanger-tol/pairs_create_contact_maps/nextflow.config
 includeConfig 'subworkflows/sanger-tol/telo_finder/nextflow.config'
 includeConfig 'subworkflows/sanger-tol/gap_finder/nextflow.config'
 includeConfig 'subworkflows/sanger-tol/repeat_density/nextflow.config'
+includeConfig 'subworkflows/nf-core/fasta_clean_faidx/nextflow.config'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -28,11 +28,56 @@
                     "default": false,
                     "fa_icon": "fas fa-check"
                 },
-                "skip_tracks": {
-                    "type": "string",
-                    "description": "Skip generation for specified tracks",
-                    "fa_icon": "fas fa-file-signature"
+                "run_coverage": {
+                    "type": "boolean",
+                    "format": "boolean",
+                    "description": "Run and ingest the coverage analysis.",
+                    "default": false,
+                    "fa_icon": "fas fa-check"
                 },
+                "run_telomere": {
+                    "type": "boolean",
+                    "format": "boolean",
+                    "description": "Run and ingest the telomere analysis.",
+                    "default": false,
+                    "fa_icon": "fas fa-check"
+                },
+                "run_gap": {
+                    "type": "boolean",
+                    "format": "boolean",
+                    "description": "Run and ingest the gap analysis.",
+                    "default": false,
+                    "fa_icon": "fas fa-check"
+                },
+                "run_repeats": {
+                    "type": "boolean",
+                    "format": "boolean",
+                    "description": "Run and ingest the repeats analysis.",
+                    "default": false,
+                    "fa_icon": "fas fa-check"
+                },
+                "run_busco": {
+                    "type": "boolean",
+                    "format": "boolean",
+                    "description": "Run and ingest the BUSCO analysis.",
+                    "default": false,
+                    "fa_icon": "fas fa-check"
+                },
+                "run_pebble": {
+                    "type": "boolean",
+                    "format": "boolean",
+                    "description": "Run and ingest the Pebble coverage analysis.",
+                    "default": false,
+                    "fa_icon": "fas fa-check"
+                },
+                "no_tracks": {
+                    "type": "boolean",
+                    "format": "boolean",
+                    "description": "Do not generate tracks.",
+                    "default": false,
+                    "fa_icon": "fas fa-check"
+                },
+
                 "reads": {
                     "type": "array",
                     "items": {
@@ -84,6 +129,12 @@
                     "fa_icon": "fas fa-file-signature",
                     "enum": ["bwamem2", "minimap2", "AUTO"]
                 },
+                "generate_track_indexes": {
+                    "type": "boolean",
+                    "description": "Generate track indexes",
+                    "help_text": "Boolean to switch off track index generation",
+                    "fa_icon": "fas fa-check"
+                },
                 "run_hires": {
                     "type": "boolean",
                     "description": "Run High Resolution pretext maps",
@@ -127,6 +178,12 @@
                     "help_text": "Generate a snapshot of the pretext output",
                     "fa_icon": "fas fa-check"
                 },
+                "juicer_generation": {
+                    "type": "boolean",
+                    "description": "Generate a juicer map output",
+                    "help_text": "Generate a juicer map output",
+                    "fa_icon": "fas fa-check"
+                },
                 "outdir": {
                     "type": "string",
                     "format": "directory-path",
@@ -160,6 +217,13 @@
                     "help_text": "In the range 0..10, pick the minumum map mapping quality of reads to be filtered. In a multi-mapping context, 0 would keep all reads and 10 removes all multimapping reads.",
                     "minimum": 0,
                     "maximum": 10
+                },
+                "replace_dots": {
+                    "type": "boolean",
+                    "default": false,
+                    "fa_icon": "fas fa-dot-circle",
+                    "description": "Replace dots in FASTA headers with underscores.",
+                    "help_text": "Some tools may not handle FASTA headers with dots in them correctly, this option uses seqtk to replace dots with underscores."
                 }
             }
         },

--- a/subworkflows/local/accessory_files/main.nf
+++ b/subworkflows/local/accessory_files/main.nf
@@ -14,7 +14,14 @@ workflow ACCESSORY_FILES {
     longread_reads      // Channel [ val(meta), [path(file)] ]
     val_teloseq         // val(telomere_sequence)
     val_split_telomere  // val(bool)
-    val_skip_tracks     // val(csv_list)
+    val_run_telomere
+    val_run_repeats
+    val_run_coverage
+    val_run_busco
+    val_run_pebble
+    val_run_gap
+    val_track_indexes
+    val_no_tracks
     ch_reference_sizes  // Channel [ val(meta), path(file)   ]
 
 
@@ -22,15 +29,9 @@ workflow ACCESSORY_FILES {
     ch_empty_file       = channel.fromPath("${baseDir}/assets/EMPTY.txt")
 
     //
-    // NOTE: THIS IS DUPLICATED IN THE CURATIONPRETEXT WORKFLOW
-    //
-    dont_generate_tracks  = val_skip_tracks ? val_skip_tracks.split(",") : "NONE"
-
-
-    //
     // SUBWORKFLOW: GENERATES A GAP.BED FILE TO ID THE LOCATIONS OF GAPS
     //
-    if (dont_generate_tracks.contains("gap") || dont_generate_tracks.contains("ALL")) {
+    if (!val_run_gap || val_no_tracks) {
         gap_file            = ch_empty_file
     } else {
         GAP_FINDER (
@@ -44,7 +45,7 @@ workflow ACCESSORY_FILES {
     //
     // SUBWORKFLOW: GENERATE TELOMERE WINDOW FILES WITH LONGREAD READS AND REFERENCE
     //
-    if (dont_generate_tracks.contains("telo") || dont_generate_tracks.contains("ALL")) {
+    if (!val_run_telomere || val_no_tracks) {
         telo_file       = ch_empty_file
     } else {
         TELO_FINDER (
@@ -62,7 +63,7 @@ workflow ACCESSORY_FILES {
     //
     // SUBWORKFLOW: GENERATES A BIGWIG FOR A REPEAT DENSITY TRACK
     //
-    if (dont_generate_tracks.contains("repeats") || dont_generate_tracks.contains("ALL")) {
+    if (!val_run_repeats || val_no_tracks) {
         repeat_file     = ch_empty_file
     } else {
         REPEAT_DENSITY (
@@ -76,7 +77,7 @@ workflow ACCESSORY_FILES {
     //
     // SUBWORKFLOW: Takes reference, longread reads
     //
-    if (dont_generate_tracks.contains("coverage") || dont_generate_tracks.contains("ALL"))  {
+    if (!val_run_coverage || val_no_tracks) {
         coverage_output = ch_empty_file
     } else {
         READ_COVERAGE (

--- a/subworkflows/local/utils_nfcore_curationpretext_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_curationpretext_pipeline/main.nf
@@ -92,7 +92,7 @@ workflow PIPELINE_INITIALISATION {
         before_text,
         after_text,
         command,
-        false
+        true
     )
 
     //

--- a/subworkflows/nf-core/fasta_clean_faidx/main.nf
+++ b/subworkflows/nf-core/fasta_clean_faidx/main.nf
@@ -1,0 +1,137 @@
+include { GUNZIP                        } from "../../../modules/nf-core/gunzip/main"
+include { SEQKIT_SEQ                    } from '../../../modules/nf-core/seqkit/seq/main'
+include { SEQKIT_REPLACE as SEQKIT_DOTS } from '../../../modules/nf-core/seqkit/replace/main'
+include { SAMTOOLS_FAIDX                } from "../../../modules/nf-core/samtools/faidx/main"
+include { SAMTOOLS_DICT                 } from "../../../modules/nf-core/samtools/dict/main"
+
+workflow FASTA_CLEAN_FAIDX {
+    take:
+    ch_reference          // channel.of( [meta], reference )
+    val_replace_dots      // boolean: replace dots in headers with underscores in trimmed reference
+    val_get_chromsizes    // boolean: emit chromsizes
+    val_get_dict          // boolean: emit dict
+
+    main:
+
+    //
+    // LOGIC: SPLIT THE INPUT REFERENCES INTO THOSE THAT ARE ZIPPED OR UNZIPPED
+    //        THIS ENSURES THAT ALL INPUT ARE UNZIPPED FOR DOWNSTREAM PROCESSING
+    //
+    ch_input = ch_reference
+            .branch { _meta, file ->
+                zipped: file.name.endsWith('.gz')
+                unzipped: !file.name.endsWith('.gz')
+            }
+
+
+    //
+    // MODULE: UNZIP INPUTS IF NEEDED
+    //
+    GUNZIP (
+        ch_input.zipped
+    )
+
+
+    //
+    // LOGIC: MIX CHANELS WHICH MAY OR MAY NOT BE EMPTY INTO A SINGLE QUEUE CHANNEL
+    //
+    unzipped_reference = ch_input.unzipped
+        .mix(GUNZIP.out.gunzip)
+
+
+    //
+    // MODULE: UPPERCASE THE REFERENCE SEQUENCE
+    //         ALSO RETURN ONLY THE ID OF A SEQUENCE NOT THE FULL HEADER
+    //
+    SEQKIT_SEQ (
+        unzipped_reference
+    )
+
+
+    //
+    // MODULE: REPLACE `.` IN HEADERS WITH `_`
+    //         `.` CAN CAUSE ISSUES FOR SOME DOWNSTREAM TOOLS
+    //         CONTROLLING THIS ON val_replace_dots ALLOWS US TO STAY INSIDE OF
+    //         SOME STANDARDS (e.g. ONLY TAKE FIRST WORK IN HEADER)
+    //
+    if (val_replace_dots) {
+        SEQKIT_DOTS (
+            SEQKIT_SEQ.out.fastx,
+            "fasta"
+        )
+
+        renamed_fasta = SEQKIT_DOTS.out.fastx
+    } else {
+        renamed_fasta = SEQKIT_SEQ.out.fastx
+    }
+
+
+    //
+    // MODULE: GENERATE INDEX OF REFERENCE FASTA
+    //         OPTIONALLY EMIT CHROMOSOME SIZES FILE
+    //
+    SAMTOOLS_FAIDX (
+        renamed_fasta.map { meta, file -> [meta, file, []] },
+        val_get_chromsizes
+    )
+
+
+    //
+    // MODULE: GENERATE GENOME STATS FROM FASTA INDEX
+    //
+    GENOME_STATS (
+        SAMTOOLS_FAIDX.out.fai
+    )
+
+
+    //
+    // MODULE: GENERATE A SAMTOOLS DICT FILE BASED ON THE CORRECTED FASTA FILE
+    //
+    SAMTOOLS_DICT (
+        renamed_fasta.filter { meta, file -> val_get_dict }
+    )
+
+
+    emit:
+    reference               = renamed_fasta
+    fai                     = SAMTOOLS_FAIDX.out.fai
+    sizes                   = SAMTOOLS_FAIDX.out.sizes
+    dict                    = SAMTOOLS_DICT.out.dict
+    sequence_description    = GENOME_STATS.out.json
+}
+
+process GENOME_STATS {
+    executor "local"
+
+    input:
+    // NOTE: Due to how the staging of files works, inputting the fai as a path
+    //       results in the process trying to seach in the wrong place.
+    tuple val(meta), val(fai)
+
+    output:
+    tuple val(meta), path("*.json"), emit: json
+
+    exec:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def outfile = task.workDir.resolve("${prefix}.json")
+
+    def lengths = fai.readLines()
+        .findAll { line -> line.trim() }
+        .collect { line -> line.split('\t')[1].toLong() }
+
+    def sequence_map = [
+            n_sequences : lengths.size(),
+            total_length: lengths.sum() ?: 0L,
+        ]
+
+    if (lengths) {
+        sequence_map.max_length = lengths.max()
+    }
+
+    outfile.text = groovy.json.JsonOutput.prettyPrint(
+        groovy.json.JsonOutput.toJson(sequence_map)
+    )
+
+    // NOTE: Using the new File syntax writes the file to the top of the workdir
+    //       resulting in the process being unable to find the file inside it self.
+}

--- a/subworkflows/nf-core/fasta_clean_faidx/meta.yml
+++ b/subworkflows/nf-core/fasta_clean_faidx/meta.yml
@@ -1,0 +1,87 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/sanger-tol/nf-core-modules/main/subworkflows/yaml-schema.json
+name: "fasta_clean_faidx"
+description: Ensure input fasta assemblies are unzipped and indexed, optionally generating a chromosome sizes file.
+keywords:
+  - index
+  - faidx
+  - dict
+  - gunzip
+  - fasta
+components:
+  - gunzip
+  - seqkit/seq
+  - seqkit/replace
+  - samtools/faidx
+  - samtools/dict
+
+input:
+  - ch_reference:
+      type: file
+      description: |
+        Input fasta reference assembly.
+
+        Structure: [ val(meta), path(fasta) ]
+      pattern: "*.{(fasta,fa,fna)(.gz)}"
+
+  - val_replace_dots:
+      type: boolean
+      description: |
+        Whether to replace dots in the fasta reference name with underscores.
+
+        Some tools can't handle dots in the fasta name, however,
+        sometimes the ID must remain unchanged.
+
+  - val_get_chromsizes:
+      type: boolean
+      description: |
+        Whether to generate a chromosome sizes file from the fasta reference.
+
+  - val_get_dict:
+      type: boolean
+      description: |
+        Whether to generate a SAMTOOLS dictionary file from the fasta reference.
+
+output:
+  - reference:
+      type: file
+      description: |
+        Input fasta reference assembly.
+
+        Structure: [ val(meta), path(fasta) ]
+      pattern: "*.{fasta,fa,fna}"
+
+  - fai:
+      type: file
+      description: |
+        SAMTOOLS FASTA index file.
+
+        Structure: [ val(meta), path(fai) ]
+      pattern: "*.fai"
+
+  - sizes:
+      type: file
+      description: |
+        Chromosome sizes file - a TSV with two columns (name and size) and no header line.
+
+        Structure: [ val(meta), path(sizes) ]
+      pattern: "*.{sizes,tsv}"
+
+  - dict:
+      type: file
+      description: |
+        SAMTOOLS dictionary file.
+
+        Structure: [ val(meta), path(dict) ]
+      pattern: "*.dict"
+
+  - sequence_description:
+      type: file
+      description: |
+        JSON file containing number of sequences, total sequence length and max_length.
+
+        Structure: [ val(meta), path(sequence_description) ]
+      pattern: "*.json"
+authors:
+  - "@DLBPointon"
+maintainers:
+  - "@DLBPointon"

--- a/subworkflows/nf-core/fasta_clean_faidx/nextflow.config
+++ b/subworkflows/nf-core/fasta_clean_faidx/nextflow.config
@@ -1,0 +1,14 @@
+process {
+    withName: '.*:FASTA_CLEAN_FAIDX:SEQKIT_SEQ' {
+        // --only-id = EXTRACT THE SEQUENCE ID NOT THE FULL HEADER
+        // -u        = UPPERCASE THE SEQUENCE
+        // -v        = VALIDATE THE SEQUENCE ALPHABET
+        ext.args = '-u -v --only-id'
+    }
+
+    withName: '.*:FASTA_CLEAN_FAIDX:SEQKIT_DOTS' {
+        // REPLACE DOTS IN SEQUENCE ID WITH UNDERSCORES
+        ext.args = "-p '\\.' -r '_'"
+        ext.prefix = { "${meta.id}_dots" }
+    }
+}

--- a/subworkflows/nf-core/fasta_clean_faidx/tests/main.nf.test
+++ b/subworkflows/nf-core/fasta_clean_faidx/tests/main.nf.test
@@ -1,0 +1,196 @@
+nextflow_workflow {
+    name "Test Subworkflow FASTA_CLEAN_FAIDX"
+    script "../main.nf"
+    config "./nextflow.config"
+    workflow "FASTA_CLEAN_FAIDX"
+
+    tag "subworkflows"
+    tag "subworkflows_nfcore"
+    tag "subworkflows/fasta_clean_faidx"
+    tag "gunzip"
+    tag "seqkit/seq"
+    tag "seqkit/replace"
+    tag "samtools/faidx"
+    tag "samtools/dict"
+
+
+    test("Bacteroides fragilis genome [fasta] w/ index") {
+        when {
+
+            params {
+                outdir = "test"
+            }
+
+            workflow {
+                """
+                input[0] = channel.of(
+                    [
+                        [ id: 'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
+                    ]
+                )
+                input[1] = true
+                input[2] = true
+                input[3] = true
+                """
+            }
+
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    path(workflow.out.dict[0][1]).readLines()[0],
+                    path(workflow.out.reference[0][1]).readLines()[0],
+                    workflow.out.reference,
+                    workflow.out.fai,
+                    workflow.out.sizes,
+                    workflow.out.sequence_description
+                ).match() }
+            )
+        }
+    }
+
+    test("Bacteroides fragilis genome [fasta] w/ index - keep dots") {
+        when {
+
+            params {
+                outdir = "test"
+            }
+
+            workflow {
+                """
+                input[0] = channel.of(
+                    [
+                        [ id: 'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
+                    ]
+                )
+                input[1] = false
+                input[2] = true
+                input[3] = true
+                """
+            }
+
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    path(workflow.out.dict[0][1]).readLines()[0],
+                    path(workflow.out.reference[0][1]).readLines()[0],
+                    workflow.out.reference,
+                    workflow.out.fai,
+                    workflow.out.sizes,
+                    workflow.out.sequence_description
+                ).match() }
+            )
+        }
+    }
+
+    test("Bacteroides fragilis genome [fasta] w/ index no sizes") {
+        when {
+
+            params {
+                outdir = "test"
+            }
+
+            workflow {
+                """
+                input[0] = channel.of(
+                    [
+                        [ id: 'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
+                    ]
+                )
+                input[1] = true
+                input[2] = false
+                input[3] = true
+                """
+            }
+
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    path(workflow.out.dict[0][1]).readLines()[0],
+                    path(workflow.out.reference[0][1]).readLines()[0],
+                    workflow.out.reference,
+                    workflow.out.fai,
+                    workflow.out.sequence_description
+                ).match() }
+            )
+        }
+    }
+
+    test("Bacteroides fragilis genome [fasta] w/ index no sizes no dict") {
+        when {
+
+            params {
+                outdir = "test"
+            }
+            workflow {
+                """
+                input[0] = channel.of(
+                    [
+                        [ id: 'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
+                    ]
+                )
+                input[1] = true
+                input[2] = false
+                input[3] = false
+                """
+            }
+
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(workflow.out).match() }
+            )
+        }
+    }
+
+    test("Bacteroides fragilis genome - stub") {
+        options "-stub"
+        when {
+
+            params {
+                outdir = "test"
+            }
+
+            workflow {
+                """
+                input[0] = channel.of(
+                    [
+                        [ id: 'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/genome/genome.fna.gz', checkIfExists: true)
+                    ]
+                )
+                input[1] = true
+                input[2] = true
+                input[3] = true
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(
+                    path(workflow.out.dict[0][1]).readLines()[0],
+                    workflow.out.reference,
+                    workflow.out.fai,
+                    workflow.out.sizes,
+                    workflow.out.sequence_description
+                ).match() }
+            )
+        }
+    }
+}

--- a/subworkflows/nf-core/fasta_clean_faidx/tests/main.nf.test.snap
+++ b/subworkflows/nf-core/fasta_clean_faidx/tests/main.nf.test.snap
@@ -1,0 +1,236 @@
+{
+    "Bacteroides fragilis genome [fasta] w/ index - keep dots": {
+        "content": [
+            "@HD\tVN:1.0\tSO:unsorted",
+            ">NZ_CP069563.1",
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.fasta:md5,96aa7707b864499745e8946f169ae8e0"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.fasta.fai:md5,f1373ef38f3777bcf9567be2e1f5c468"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.fasta.sizes:md5,acc65893c145aa8385e4afb4f4662623"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.json:md5,1e536d080509f7fc34114f0bc58a514d"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-28T17:29:22.581741203",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.6"
+        }
+    },
+    "Bacteroides fragilis genome [fasta] w/ index": {
+        "content": [
+            "@HD\tVN:1.0\tSO:unsorted",
+            ">NZ_CP069563_1",
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_dots.fasta:md5,28d52b0bfeaf9e303cf7cb27f3f97591"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_dots.fasta.fai:md5,6738578d233b2d58148a968fcefc9177"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_dots.fasta.sizes:md5,228324d51a226de6bf3532f5e7d99b33"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.json:md5,1e536d080509f7fc34114f0bc58a514d"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-28T12:57:01.005284326",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.6"
+        }
+    },
+    "Bacteroides fragilis genome - stub": {
+        "content": [
+            null,
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_dots.fasta:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_dots.fasta.fai:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_dots.fasta.sizes:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.json:md5,d66d2fad00f0873fa822f798e6c78a79"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-26T10:00:40.646135832",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
+    },
+    "Bacteroides fragilis genome [fasta] w/ index no sizes no dict": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_dots.fasta:md5,28d52b0bfeaf9e303cf7cb27f3f97591"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_dots.fasta.fai:md5,6738578d233b2d58148a968fcefc9177"
+                    ]
+                ],
+                "2": [
+                    
+                ],
+                "3": [
+                    
+                ],
+                "4": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.json:md5,1e536d080509f7fc34114f0bc58a514d"
+                    ]
+                ],
+                "dict": [
+                    
+                ],
+                "fai": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_dots.fasta.fai:md5,6738578d233b2d58148a968fcefc9177"
+                    ]
+                ],
+                "reference": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test_dots.fasta:md5,28d52b0bfeaf9e303cf7cb27f3f97591"
+                    ]
+                ],
+                "sequence_description": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.json:md5,1e536d080509f7fc34114f0bc58a514d"
+                    ]
+                ],
+                "sizes": [
+                    
+                ]
+            }
+        ],
+        "timestamp": "2026-08-28T17:29:42.76692073",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.6"
+        }
+    },
+    "Bacteroides fragilis genome [fasta] w/ index no sizes": {
+        "content": [
+            "@HD\tVN:1.0\tSO:unsorted",
+            ">NZ_CP069563_1",
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_dots.fasta:md5,28d52b0bfeaf9e303cf7cb27f3f97591"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test_dots.fasta.fai:md5,6738578d233b2d58148a968fcefc9177"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test"
+                    },
+                    "test.json:md5,1e536d080509f7fc34114f0bc58a514d"
+                ]
+            ]
+        ],
+        "timestamp": "2026-08-28T17:29:32.864768835",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.6"
+        }
+    }
+}

--- a/subworkflows/nf-core/fasta_clean_faidx/tests/nextflow.config
+++ b/subworkflows/nf-core/fasta_clean_faidx/tests/nextflow.config
@@ -1,0 +1,14 @@
+process {
+    withName: 'SEQKIT_SEQ' {
+        // --only-id = EXTRACT THE SEQUENCE ID NOT THE FULL HEADER
+        // -u        = UPPERCASE THE SEQUENCE
+        // -v        = VALIDATE THE SEQUENCE ALPHABET
+        ext.args = '-u -v --only-id'
+    }
+
+    withName: 'SEQKIT_DOTS' {
+        // REPLACE DOTS IN SEQUENCE ID WITH UNDERSCORES
+        ext.args = "-p '\\.' -r '_'"
+        ext.prefix = { "${meta.id}_dots" }
+    }
+}

--- a/workflows/curationpretext.nf
+++ b/workflows/curationpretext.nf
@@ -4,12 +4,10 @@
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-// NF-CORE MODULES
-include { GAWK as GAWK_UPPER_SEQUENCE                       } from '../modules/nf-core/gawk/main'
-include { SAMTOOLS_FAIDX                                    } from '../modules/nf-core/samtools/faidx/main'
-include { GUNZIP                                            } from '../modules/nf-core/gunzip/main'
+// NF-CORE SUBWORKFLOWS
+include { FASTA_CLEAN_FAIDX                                 } from '../subworkflows/nf-core/fasta_clean_faidx/main'
 
-//LOCAL MODULES
+// LOCAL MODULES
 include { PRETEXT_GRAPH as PRETEXT_INGEST_SNDRD             } from '../modules/local/pretext/graph/main'
 include { PRETEXT_GRAPH as PRETEXT_INGEST_HIRES             } from '../modules/local/pretext/graph/main'
 include { PRETEXT_GRAPH as PRETEXT_INGEST_ULTRA             } from '../modules/local/pretext/graph/main'
@@ -22,6 +20,9 @@ include { CRAM_MAP_ILLUMINA_HIC as ALIGN_CRAM               } from '../subworkfl
 include { PAIRS_CREATE_CONTACT_MAPS as CREATE_MAPS_STDRD    } from '../subworkflows/sanger-tol/pairs_create_contact_maps/main'
 include { PAIRS_CREATE_CONTACT_MAPS as CREATE_MAPS_HIRES    } from '../subworkflows/sanger-tol/pairs_create_contact_maps/main'
 include { PAIRS_CREATE_CONTACT_MAPS as CREATE_MAPS_ULTRA    } from '../subworkflows/sanger-tol/pairs_create_contact_maps/main'
+
+// SANGER-TOL MODULES
+include { PRETEXTANNOTATE                                   } from '../modules/sanger-tol/pretextannotate/main'
 
 // FUNCTION IMPORTS
 include { paramsSummaryMap                                  } from 'plugin/nf-schema'
@@ -41,61 +42,37 @@ workflow CURATIONPRETEXT {
     ch_cram_reads
     ch_mapped_bam
     ch_snapshot_order
+    val_snapshot_generation
+    val_snapshot_annotate
+    val_juicer_generation
     val_teloseq
-    val_input_file_string
-    val_aligner
-    val_skip_tracks
+    val_selected_aligner
+    val_run_gap
+    val_run_telomere
+    val_run_repeats
+    val_run_coverage
+    val_run_busco
+    val_run_pebble
     val_run_hires
     val_run_ultra
+    val_no_tracks
     val_split_telomere
     val_cram_chunk_size
+    val_replace_dots
+    val_track_indexes
     outdir
 
     main:
-    ch_empty_file       = channel.fromPath("${baseDir}/assets/EMPTY.txt")
-
-    ch_reference
-        .branch { _meta, file ->
-            zipped: file.name.endsWith('.gz')
-            unzipped: !file.name.endsWith('.gz')
-        }
-        .set {ch_input}
 
     //
-    // MODULE: UNZIP INPUTS IF NEEDED
+    // SUBWORKFLOW: UNZIP FASTA, UPPERCASE SEQUENCE,
+    //              CLEAN HEADER (optional) AND GENERATE INDEX
     //
-    GUNZIP (
-        ch_input.zipped
-    )
-
-
-    //
-    // LOGIC: MIX CHANELS WHICH MAY OR MAY NOT BE EMPTY INTO A SINGLE QUEUE CHANNEL
-    //
-    unzipped_input = channel.empty()
-
-    unzipped_input
-        .mix(ch_input.unzipped, GUNZIP.out.gunzip)
-        .set { unzipped_reference }
-
-
-    //
-    // MODULE: UPPERCASE THE REFERENCE SEQUENCE
-    //
-    GAWK_UPPER_SEQUENCE(
-        unzipped_reference,
-        [],
-        false,
-    )
-    ch_upper_ref    = GAWK_UPPER_SEQUENCE.out.output
-
-
-    //
-    // MODULE: GENERATE INDEX OF REFERENCE FASTA
-    //
-    SAMTOOLS_FAIDX (
-        ch_upper_ref.map { meta, file -> [meta, file, []] },
-        true
+    FASTA_CLEAN_FAIDX (
+        ch_reference,
+        val_replace_dots,
+        true,               // We always want the .sizes file
+        false               // We don't need the .dict file
     )
 
 
@@ -103,72 +80,66 @@ workflow CURATIONPRETEXT {
     // LOGIC: IN SOME CASES THE USER MAY NOT NEED ALL OR A SELECT GROUP OF
     //          ACCESSORY FILES SO WE HAVE AN OPTION TO TURN THEM OFF
     //
-
-    dont_generate_tracks  = val_skip_tracks ? val_skip_tracks.split(",") : "NONE"
-
     full_list = [
-        "gap",
-        "telo",
-        "repeats",
-        "coverage",
-        "NONE",
-        "ALL"
+        "gap track": val_run_gap,
+        "telomere track": val_run_telomere,
+        "repeats track": val_run_repeats,
+        "coverage track": val_run_coverage,
+        "busco track": val_run_busco,
+        "pebble track": val_run_pebble
     ]
 
-    if (!full_list.containsAll(dont_generate_tracks) && !full_list.containsAll(dont_generate_tracks)) {
-        exit 1, "There is an extra argument given on Command Line: \n Check contents of: $dont_generate_tracks\nMaster list is: $full_list"
-    }
 
-    log.info "SKIPPING TRACK GENERATION FOR: $dont_generate_tracks"
+    log.info "ACCESSORY TRACK OPTIONS: $full_list"
 
-    if (dont_generate_tracks.contains("ALL")) {
-        gaps_file           = ch_empty_file
-        cove_file           = ch_empty_file
-        telo_file           = ch_empty_file
-        rept_file           = ch_empty_file
+    ch_empty_file       = channel.fromPath("${baseDir}/assets/EMPTY.txt")
+
+    if (val_no_tracks) {
+        gaps_file       = ch_empty_file
+        cove_file       = ch_empty_file
+        telo_file       = ch_empty_file
+        rept_file       = ch_empty_file
+        busc_file       = ch_empty_file
+        pebb_file       = ch_empty_file
 
     } else {
         //
         // SUBWORKFLOW: GENERATE SUPPLEMENTARY FILES FOR PRETEXT INGESTION
         //
         ACCESSORY_FILES (
-            ch_upper_ref,
+            FASTA_CLEAN_FAIDX.out.reference.map{ meta, file -> tuple([id: meta.id], file) },
             ch_reads,
             val_teloseq,
             val_split_telomere,
-            val_skip_tracks,
-            SAMTOOLS_FAIDX.out.sizes
+            val_run_telomere,
+            val_run_repeats,
+            val_run_coverage,
+            val_run_busco,
+            val_run_pebble,
+            val_run_gap,
+            val_track_indexes,
+            val_no_tracks,
+            FASTA_CLEAN_FAIDX.out.sizes
         )
 
-        gaps_file           = ACCESSORY_FILES.out.gap_file
-        cove_file           = ACCESSORY_FILES.out.coverage_output
-        telo_file           = ACCESSORY_FILES.out.telo_file
-        rept_file           = ACCESSORY_FILES.out.repeat_file
+        gaps_file       = ACCESSORY_FILES.out.gap_file
+        cove_file       = ACCESSORY_FILES.out.coverage_output
+        telo_file       = ACCESSORY_FILES.out.telo_file
+        rept_file       = ACCESSORY_FILES.out.repeat_file
     }
-
-
-    //
-    // LOGIC: IDEALLY THIS SHOULD BE DONE IN THE PIPELINE_INITIALISATION
-    //        SUBWORKFLOW, HOWEVER, THE VALUE WOULD BE CONVERTED TO A CHANNEL
-    //        WHICH THEN CANNOT BE USED TO GENERATE A STRING FOR THE SW
-    //
-    def fasta_size = file(val_input_file_string).size()
-    def selected_aligner = (val_aligner == "AUTO") ?
-        (fasta_size > 5e9 ? "minimap2" : "bwamem2") :
-        val_aligner
 
 
     //
     // SUBWORKFLOW: MAP CRAM IF READS NOT ALREADY MAPPED
     //
     ALIGN_CRAM (
-        ch_upper_ref,
+        FASTA_CLEAN_FAIDX.out.reference,
         ch_cram_reads,
-        selected_aligner,
+        val_selected_aligner,
         val_cram_chunk_size
     )
 
-    mapped_bam = ch_mapped_bam.mix( ALIGN_CRAM.out.bam )
+    mapped_bam          = ch_mapped_bam.mix( ALIGN_CRAM.out.bam )
 
 
     //
@@ -176,22 +147,42 @@ workflow CURATIONPRETEXT {
     //        OTHERWISE, THE MODULE SHOULD STILL RUN WITHOUT ORDERING AND
     //        PRODUCE AN EMPTY CHANNEL. ONLY NEEDED FOR STDRD
     //
-    ch_snapshot_custom_order = ch_upper_ref
+    ch_snapshot_custom_order = FASTA_CLEAN_FAIDX.out.reference
         .combine(ch_snapshot_order)
         .map { meta, _fasta, order_file -> [meta, order_file] }
 
+
     //
     // SUBWORKFLOW: MAP THE PRETEXT FILE AND TAKE SNAPSHOT
+    //              STNDRD IS THE ONLY VARIANT WE ARE ANNOTATING WITH OTHER PARAMS
+    //              DUE TO HOW RESOURCE INTENSIVE THEY SNAPSHOT IS WITH HIGHER RESOLUTION
+    //              AND WE ONLY NEED 1 JUICER MAP
     //
     CREATE_MAPS_STDRD (
         mapped_bam,
         [[:],[]],
         ch_snapshot_custom_order,
-        true,
-        params.snapshot_generation,
-        false,
-        false,
-        []
+        true,                       // Pretext generation, always true
+        val_snapshot_generation,
+        false,                      // cooler map generation, which we won't be using
+        val_juicer_generation,      // Juicer generation, optional need for genomenotes
+        []                          // Cooler cload parameters
+    )
+
+
+    //
+    // MODULE: ANNOTATE THE PRETEXT SNAPSHOT FILE WITH SCAFFOLD NAMES AND SIZES
+    //
+    filtered_sizes = FASTA_CLEAN_FAIDX.out.sizes.filter { _meta, _file -> val_snapshot_annotate }
+
+    filtered_sizes.map { _meta, _file ->
+        log.warn "Annotation currently relies on the original FASTA sizes file generated as part of this pipeline!"
+        log.warn "This means that if you've supplied a custom order for the snapshot, the annotation will be wrong!"
+    }
+
+    PRETEXTANNOTATE(
+        filtered_sizes,
+        CREATE_MAPS_STDRD.out.pretext_png
     )
 
 
@@ -214,10 +205,10 @@ workflow CURATIONPRETEXT {
     //              IF val_run_ultra IS "true" CALCULATE WHETHER THE REF IS > 4GB AND MAP ULTRA
     //              IF val_run_ultra IS "force" MAP ULTRA
     //
-    def ultra_input = mapped_bam
-        .combine(ch_reference)
+    def ultra_input     = mapped_bam
+        .combine(FASTA_CLEAN_FAIDX.out.reference)
         .filter { _mapped_meta, _bam, _ref_meta, ref_fasta ->
-            val_run_ultra == "force" || (val_run_ultra == "true" && ref_fasta.size() > 4.GB)
+            val_run_ultra == "force" || (val_run_ultra == "yes" && ref_fasta.size() > 4.GB)
         }
         .map { mapped_meta, bam, _ref_meta, _ref_fasta ->
             [mapped_meta, bam]
@@ -240,7 +231,7 @@ workflow CURATIONPRETEXT {
     //          - ADAPTED FROM TREEVAL
     //
     PRETEXT_INGEST_SNDRD (
-        CREATE_MAPS_STDRD.out.pretext.filter { !dont_generate_tracks.contains("ALL") },
+        CREATE_MAPS_STDRD.out.pretext.filter { val_no_tracks },
         gaps_file,
         cove_file,
         telo_file,
@@ -254,7 +245,7 @@ workflow CURATIONPRETEXT {
     //          - ADAPTED FROM TREEVAL
     //
     PRETEXT_INGEST_HIRES (
-        CREATE_MAPS_HIRES.out.pretext.filter { !dont_generate_tracks.contains("ALL") },
+        CREATE_MAPS_HIRES.out.pretext.filter { val_no_tracks },
         gaps_file,
         cove_file,
         telo_file,
@@ -268,7 +259,7 @@ workflow CURATIONPRETEXT {
     //          - ADAPTED FROM TREEVAL
     //
     PRETEXT_INGEST_ULTRA (
-        CREATE_MAPS_ULTRA.out.pretext.filter { !dont_generate_tracks.contains("ALL") },
+        CREATE_MAPS_ULTRA.out.pretext.filter { val_no_tracks },
         gaps_file,
         cove_file,
         telo_file,
@@ -276,7 +267,7 @@ workflow CURATIONPRETEXT {
         val_split_telomere
     )
 
-    def ch_versions = channel.empty()
+    def ch_versions     = channel.empty()
 
     //
     // Collate and save software versions
@@ -307,7 +298,7 @@ workflow CURATIONPRETEXT {
             newLine: true
         )
     emit:
-    versions       = ch_versions                 // channel: [ path(versions.yml) ]
+    versions            = ch_versions                 // channel: [ path(versions.yml) ]
 }
 
 /*


### PR DESCRIPTION
This is the first set of features to move us towards Version 2, where curationpretext and treeval will have full parity.
This will include changes to the CLI and tools used on the backend.

- Adds `FASTA_CLEAN_FAIDX` as new input cleaning subworkflow
- Separates `--skip_tracks` into a param per track, e.g., `--run_telomere {false/true}`
- Adds `PRETEXTANNOTATE` and the `--snapshot_annotation` flag

Locally tested to be working correctly.

**This is Part 1 and should not be merged in yet.**

Part 2 should include:
- corrections to Pretextannotate input, this will require subsetting of the samtools sizes file to make sure that the input sizes is correct for the `pretextsnapshot` in use.
- Update the `ACCESSORY_FILES` subworkflow to `sanger-tol/PRETEXT_ACCESSORY_FILES`
    - This is currently waiting on a fix of the TELOMERE subworkflow.
- Fix runner issues.